### PR TITLE
Allow to add new participant using existing driver in championship

### DIFF
--- a/app/Http/Controllers/RaceParticipantController.php
+++ b/app/Http/Controllers/RaceParticipantController.php
@@ -49,13 +49,37 @@ class RaceParticipantController extends Controller
     /**
      * Show the form for creating a new resource.
      *
+     * @param  \Illuminate\Http\Request  $request
      * @return \Illuminate\Http\Response
      */
-    public function create(Race $race)
+    public function create(Race $race, Request $request)
     {
+
+        $templateParticipant = null;
+
+        try {
+            $validated = $this->validate($request, [
+                'from' => [
+                    'sometimes', 
+                    'nullable', 
+                    'string', 
+                    Rule::exists('participants', 'uuid')->where(function ($query) use ($race) {
+                        return $query->where('championship_id', $race->championship_id);
+                    }),
+                ]
+            ]);
+
+            $templateParticipant = ($validated['from'] ?? false) ? Participant::whereUuid($validated['from'])->first() : null;
+
+        } catch (ValidationException $th) {
+
+        }
+
+
         return view('participant.create', [
             'race' => $race,
             'categories' => Category::all(),
+            'participant' => $templateParticipant,
         ]);
     }
 

--- a/app/Http/Livewire/ParticipantSelector.php
+++ b/app/Http/Livewire/ParticipantSelector.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Http\Livewire;
+
+use App\Models\Participant;
+use Livewire\Component;
+
+class ParticipantSelector extends Component
+{
+    /**
+     * @var \Illuminate\Support\Collection
+     */
+    public $participants;
+
+    /**
+     * @var \App\Models\Race
+     */
+    public $race;
+
+    public $search;
+
+    public function __construct($race)
+    {
+        $this->race = $race;
+        $this->search = null;
+    }
+
+    public function render()
+    {
+        $this->participants = !$this->search ? null : Participant::whereChampionshipId($this->race->championship_id)
+            ->where('race_id', '!=', $this->race->getKey())
+            ->where(function($query){
+                $query->where('bib', e($this->search))
+                    ->orWhere('first_name', 'LIKE', e($this->search).'%')
+                    ->orWhere('last_name', 'LIKE', e($this->search).'%')
+                    ->orWhere('driver_licence', hash('sha512', $this->search))
+                    ->orWhere('competitor_licence', hash('sha512', $this->search))
+                    ;
+            })
+            ->orderBy('bib', 'asc')
+            ->get();
+
+        return view('livewire.participant-selector');
+    }
+}

--- a/resources/views/livewire/participant-listing.blade.php
+++ b/resources/views/livewire/participant-listing.blade.php
@@ -1,6 +1,6 @@
 <div>
 
-    <x-search-input id="participant_search" wire:model.debounce.750ms="search" wire:keydown.enter="$set('search', $event.target.value);alert($event.target.value)" type="text" autofocus placeholder="{{ __('Search participant using bib, name, last name or licence number') }}" name="participant_search" class="block w-full sticky top-0"  />
+    <x-search-input id="participant_search" wire:model.debounce.750ms="search" wire:keydown.enter="$set('search', $event.target.value);" type="text" autofocus placeholder="{{ __('Search participant using bib, name, last name or licence number') }}" name="participant_search" class="block w-full sticky top-0"  />
 
     <div class="h-4"></div>
     

--- a/resources/views/livewire/participant-selector.blade.php
+++ b/resources/views/livewire/participant-selector.blade.php
@@ -1,0 +1,29 @@
+<div class="relative">
+    <x-search-input id="participant_search" wire:model.debounce.750ms="search" wire:keydown.enter="$set('search', $event.target.value);" type="text" placeholder="{{ __('Search participant within championship') }}" name="participant_search" class="block w-full"  />
+
+    @if ($this->participants)
+        
+        <div class="z-10 max-h-96 overflow-y-scroll absolute p-2 w-full bg-white border border-zinc-300 focus:border-orange-300 focus:ring focus:ring-orange-200 focus:ring-opacity-50 rounded-md shadow-sm space-y-2">
+            @forelse ($this->participants as $item)
+
+                <a class="-mx-2 p-2 flex items-start hover:bg-orange-300 focus:bg-orange-300 active:bg-orange-400" href="{{ route('races.participants.create', ['race' => $race->uuid, 'from' => $item->uuid]) }}">
+                    <span class="font-mono text-lg block w-1/5 text-center shrink-0 bg-gray-100 group-hover:bg-orange-200 px-2 py-1 rounded mr-2">{{ $item->bib }}</span>
+                    <span>
+                        {{ $item->first_name }} {{ $item->last_name }}
+                        <span class="text-sm text-zinc-600 block">
+                            {{ $item->category()?->name ?? $item->category }} / {{ $item->engine }}
+                        </span>
+                    </span>
+                </a>
+
+            @empty
+
+                <p class="text-zinc-600">
+                    {{ __('No participant matching your search ":terms"', ['terms' => $search]) }}
+                </p>
+
+            @endforelse
+        </div>
+    @endif
+
+</div>

--- a/resources/views/participant/create.blade.php
+++ b/resources/views/participant/create.blade.php
@@ -1,10 +1,18 @@
 <x-app-layout>
     <x-slot name="header">
-        <h2 class="font-semibold text-xl text-zinc-800 leading-tight flex gap-2">
-            <span><a href="{{ route('races.show', $race) }}">{{ $race->title }}</a></span>
-            <span>/</span>
-            <span>{{ __('Add new participant') }}</span>
-        </h2>
+        <div class="flex justify-between items-center">
+
+            <h2 class="font-semibold text-xl text-zinc-800 leading-tight flex gap-2">
+                <span><a href="{{ route('races.show', $race) }}">{{ $race->title }}</a></span>
+                <span>/</span>
+                <span>{{ __('Add new participant') }}</span>
+            </h2>
+
+            <div class="w-1/3">
+                <livewire:participant-selector :race="$race" />
+            </div>
+
+        </div>
     </x-slot>
 
 


### PR DESCRIPTION
Entering all data during the registration of a driver can be time consuming. If the driver already participated in the championship the race secretary or the organizer can search for it to precompile the participation module.