### PR TITLE
Simplify categories

### DIFF
--- a/app/Http/Livewire/CategorySelector.php
+++ b/app/Http/Livewire/CategorySelector.php
@@ -27,7 +27,9 @@ class CategorySelector extends Component
     
     public function render()
     {
-        $this->categories = $this->search ? Category::search($this->search) : Category::all();
+        $this->categories = ($this->search ? Category::search($this->search) : Category::all())->filter(function($category){
+            return $category->get('enabled', true);
+        });
 
 
         return view('livewire.category-selector');

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
         "livewire/livewire": "^2.5",
         "rinvex/countries": "^9.0",
         "spatie/laravel-activitylog": "^4.7",
+        "timokoerber/laravel-one-time-operations": "^1.3",
         "vitorccs/laravel-csv": "^1.0"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "51adaf2548ad19e118f7f592a7dc5626",
+    "content-hash": "3e5cac915f4bf8986d69acdff4b7b5cc",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",
@@ -6011,6 +6011,70 @@
                 "source": "https://github.com/tijsverkoyen/CssToInlineStyles/tree/2.2.5"
             },
             "time": "2022-09-12T13:28:28+00:00"
+        },
+        {
+            "name": "timokoerber/laravel-one-time-operations",
+            "version": "1.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/TimoKoerber/laravel-one-time-operations.git",
+                "reference": "7376604779edabfdc8400d9eccf08b8418901234"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/TimoKoerber/laravel-one-time-operations/zipball/7376604779edabfdc8400d9eccf08b8418901234",
+                "reference": "7376604779edabfdc8400d9eccf08b8418901234",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/contracts": "^9.0|^10.0",
+                "illuminate/support": "^9.0|^10.0",
+                "php": "^8.0"
+            },
+            "require-dev": {
+                "orchestra/testbench": "7",
+                "phpunit/phpunit": "^9.4"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "TimoKoerber\\LaravelOneTimeOperations\\Providers\\OneTimeOperationsServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "TimoKoerber\\LaravelOneTimeOperations\\": "src/",
+                    "TimoKoerber\\LaravelOneTimeOperations\\Database\\Factories\\": "database/factories/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "timo.koerber",
+                    "email": "koerber.timo@gmail.com",
+                    "homepage": "https://www.timokoerber.com",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Run operations once after deployment - just like you do it with migrations!",
+            "homepage": "https://github.com/timokoerber/laravel-one-time-operations",
+            "keywords": [
+                "deployment",
+                "jobs",
+                "laravel",
+                "migrations",
+                "operations"
+            ],
+            "support": {
+                "issues": "https://github.com/TimoKoerber/laravel-one-time-operations/issues",
+                "source": "https://github.com/TimoKoerber/laravel-one-time-operations/tree/1.3.1"
+            },
+            "time": "2023-04-19T12:54:36+00:00"
         },
         {
             "name": "vitorccs/laravel-csv",

--- a/config/categories.php
+++ b/config/categories.php
@@ -47,35 +47,40 @@ return [
             'name' => '60 Mini Rok (TDM)',
             'tires' => 'VEGA_MINI',
             'timekeeper_label' => 'MINIKART TERRITORIALE',
+            'enabled' => false,
         ],
         
         '60 MINI TDM EASY' => [
             'name' => '60 Easy (TDM)',
             'tires' => 'VEGA_MINI',
             'timekeeper_label' => 'MINIKART TERRITORIALE',
+            'enabled' => false,
         ],
         
         '60 MINI TDM FR ROTAX' => [
             'name' => '60 Mini FR Rotax (TDM)',
             'tires' => 'VEGA_MINI',
             'timekeeper_label' => 'MINIKART TERRITORIALE',
+            'enabled' => false,
         ],
         
         '60 MINI TDM X30' => [
             'name' => '60 Mini X30 (TDM)',
             'tires' => 'VEGA_MINI',
             'timekeeper_label' => 'MINIKART TERRITORIALE',
+            'enabled' => false,
         ],
 
         '60 MINI TERR' => [
             'name' => '60cc Territorial',
-            'description' => 'For all engine trophies (e.g. X30, Rok, ...)',
+            'description' => 'For all engine trophies including TDM (e.g. X30, Rok, Rotax, ...)',
             'tires' => 'VEGA_MINI',
             'timekeeper_label' => 'MINIKART TERRITORIALE',
         ],
         
         '125 JUNIOR TERR' => [
             'name' => '125 Junior Territorial',
+            'description' => 'For all engine trophies including TDM (e.g. X30, Rok, Rotax, ...)',
             'tires' => 'VEGA_XH3',
             'timekeeper_label' => '125 TAG JUNIOR TERR',
         ],
@@ -96,6 +101,7 @@ return [
             'name' => '125 Junior Rok (TDM)',
             'tires' => 'VEGA_XH3',
             'timekeeper_label' => '125 TAG JUNIOR TERR',
+            'enabled' => false,
         ],
         '100 JUNIOR TDM EASY' => [
             'name' => '100 Easy (TDM)',
@@ -106,10 +112,12 @@ return [
             'name' => '125 Junior X30 (TDM)',
             'tires' => 'VEGA_XH3',
             'timekeeper_label' => '125 TAG JUNIOR TERR',
+            'enabled' => false,
         ],
         
         '125 SENIOR TERR' => [
             'name' => '125 Senior Territorial',
+            'description' => 'For all engine trophies including TDM (e.g. X30, Rok, Rotax, ...)',
             'tires' => 'MG_SM',
             'timekeeper_label' => '125 TAG SENIOR TERR',
         ],
@@ -130,66 +138,77 @@ return [
             'name' => '125 Senior Rok (TDM)',
             'tires' => 'MG_SM',
             'timekeeper_label' => '125 TAG SENIOR TERR',
+            'enabled' => false,
         ],
 
         '125 SENIOR TDM SUPEROK' => [
             'name' => '125 Senior Superok (TDM)',
             'tires' => 'MG_SM',
             'timekeeper_label' => '125 TAG SENIOR TERR',
+            'enabled' => false,
         ],
 
         '125 SENIOR TDM ROTAX MAX' => [
             'name' => '125 Senior Rotax Max (TDM)',
             'tires' => 'MG_SM',
             'timekeeper_label' => '125 TAG SENIOR TERR',
+            'enabled' => false,
         ],
 
         '125 SENIOR TDM BMB' => [
             'name' => '125 Senior BMB (TDM)',
             'tires' => 'MG_SM',
             'timekeeper_label' => '125 TAG SENIOR TERR',
+            'enabled' => false,
         ],
 
         '125 SENIOR TDM X30' => [
             'name' => '125 Senior X30 (TDM)',
             'tires' => 'MG_SM',
             'timekeeper_label' => '125 TAG SENIOR TERR',
+            'enabled' => false,
         ],
 
         '125 SENIOR TDM SHIFTER ROK' => [
             'name' => '125 Senior Shifter Rok (TDM)',
             'tires' => 'MG_SM',
             'timekeeper_label' => '125 TAG SENIOR TERR',
+            'enabled' => false,
         ],
 
         '125 SENIOR TDM KGP SHIFTER' => [
             'name' => '125 Senior KGP Shifter (TDM)',
             'tires' => 'MG_SM',
             'timekeeper_label' => '125 TAG SENIOR TERR',
+            'enabled' => false,
         ],
 
         '125 SENIOR TDM X30 SUPER SHIFTER' => [
             'name' => '125 Senior X30 Super Shifter (TDM)',
             'tires' => 'MG_SM',
             'timekeeper_label' => '125 TAG SENIOR TERR',
+            'enabled' => false,
         ],
 
         '125 SENIOR TDM KGP DIRECT DRIVE' => [
             'name' => '125 Senior KGP Direct Drive (TDM)',
             'tires' => 'MG_SM',
             'timekeeper_label' => '125 TAG SENIOR TERR',
+            'enabled' => false,
         ],
 
         '125 SENIOR TDM ROTAX DD2' => [
             'name' => '125 Senior Rotax DD2 (TDM)',
             'tires' => 'MG_SM',
             'timekeeper_label' => '125 TAG SENIOR TERR',
+            'enabled' => false,
         ],
 
         '125 SENIOR TDM X30 SUPER' => [
             'name' => '125 Senior X30 Super (TDM)',
             'tires' => 'MG_SM',
             'timekeeper_label' => '125 TAG SENIOR TERR',
+            'enabled' => false,
         ],
         
         '125 MASTER TERR' => [

--- a/config/categories.php
+++ b/config/categories.php
@@ -213,6 +213,7 @@ return [
         
         '125 MASTER TERR' => [
             'name' => '125 Master Territorial',
+            'description' => 'For all engine trophies including TDM (e.g. X30, Rok, Rotax, ...)',
             'tires' => 'MG_SM',
             'timekeeper_label' => '125 MASTER TERR',
         ],

--- a/operations/2023_04_21_120712_move_participant_from_tdm_to_territorial.php
+++ b/operations/2023_04_21_120712_move_participant_from_tdm_to_territorial.php
@@ -1,0 +1,53 @@
+<?php
+
+use App\Models\Participant;
+use TimoKoerber\LaravelOneTimeOperations\OneTimeOperation;
+
+return new class extends OneTimeOperation
+{
+    /**
+     * This moves all participants registered
+     * in TDM categories to the corresponding
+     * territorial ones
+     */
+    public function process(): void
+    {
+        $categoriesToTransfer = [
+            '60 MINI TDM ROK' => '60 MINI TERR',
+            '60 MINI TDM EASY' => '60 MINI TERR',
+            '60 MINI TDM FR ROTAX' => '60 MINI TERR',
+            '60 MINI TDM X30' => '60 MINI TERR',
+
+            '125 JUNIOR TDM ROK' => '125 JUNIOR TERR',
+            '125 JUNIOR TDM X30' => '125 JUNIOR TERR',
+
+            '125 SENIOR TDM ROK' => '125 SENIOR TERR',
+            '125 SENIOR TDM SUPEROK' => '125 SENIOR TERR',
+            '125 SENIOR TDM ROTAX MAX' => '125 SENIOR TERR',
+            '125 SENIOR TDM BMB' => '125 SENIOR TERR',
+            '125 SENIOR TDM X30' => '125 SENIOR TERR',
+            '125 SENIOR TDM SHIFTER ROK' => '125 SENIOR TERR',
+            '125 SENIOR TDM KGP SHIFTER' => '125 SENIOR TERR',
+            '125 SENIOR TDM X30 SUPER SHIFTER' => '125 SENIOR TERR',
+            '125 SENIOR TDM KGP DIRECT DRIVE' => '125 SENIOR TERR',
+            '125 SENIOR TDM ROTAX DD2' => '125 SENIOR TERR',
+            '125 SENIOR TDM X30 SUPER' => '125 SENIOR TERR',
+        ];
+
+
+        Participant::query()
+            ->whereIn('category', array_keys($categoriesToTransfer))
+            ->lazy()->each(function($participant) use ($categoriesToTransfer) {
+                $participant->category = $categoriesToTransfer[$participant->category] ?? $participant->category;
+                
+                logs()->info("Migrating participant category", [
+                    'id' => $participant->getKey(),
+                    'new' => $participant->category,
+                    'old' => $participant->getOriginal('category'),
+                ]);
+
+                $participant->save();
+
+            });
+    }
+};

--- a/tests/Feature/Operations/MigrateParticipantsFromTdmToTerritorialTest.php
+++ b/tests/Feature/Operations/MigrateParticipantsFromTdmToTerritorialTest.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace Tests\Feature\Operations;
+
+use App\Models\Participant;
+use App\Models\Race;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Tests\TestCase;
+
+class MigrateParticipantsFromTdmToTerritorialTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_participants_in_tmd_categories_are_updated()
+    {
+
+        config([
+            'categories.default' => [
+                '125 SENIOR TDM ROK' => [
+                    'name' => '125 Senior Rok (TDM)',
+                    'tires' => 'MG_SM',
+                    'timekeeper_label' => '125 TAG SENIOR TERR',
+                    'enabled' => false,
+                ],
+        
+                '125 SENIOR TDM SUPEROK' => [
+                    'name' => '125 Senior Superok (TDM)',
+                    'tires' => 'MG_SM',
+                    'timekeeper_label' => '125 TAG SENIOR TERR',
+                    'enabled' => false,
+                ],
+
+                '125 SENIOR TERR' => [
+                    'name' => '125 Senior Territorial',
+                    'description' => 'For all engine trophies including TDM (e.g. X30, Rok, Rotax, ...)',
+                    'tires' => 'MG_SM',
+                    'timekeeper_label' => '125 TAG SENIOR TERR',
+                ],
+            ],
+        ]);
+
+        
+        $race = Race::factory()
+            ->create([
+                'event_start_at' => Carbon::parse("2023-02-28"),
+                'title' => 'Race title'
+            ]);
+        
+        $actual_participant = Participant::factory()->create([
+            'category' => '125 SENIOR TDM SUPEROK',
+            'race_id' => $race->getKey(),
+            'championship_id' => $race->championship->getKey(),
+        ]);
+
+        $this->artisan("operations:process", [
+                '--test' => true,
+                '2023_04_21_120712_move_participant_from_tdm_to_territorial',
+            ])
+            ->assertSuccessful();
+
+        $participant = $actual_participant->fresh();
+
+        $lastActivity = $participant->activities()->get()->last();
+
+        $this->assertEquals('125 SENIOR TERR', $participant->category);
+        $this->assertEquals('updated', $lastActivity->event);
+        $this->assertEquals('participant', $lastActivity->subject_type);
+        $this->assertEquals(['category' => '125 SENIOR TERR'], $lastActivity->changes()->get('attributes'));
+        $this->assertEquals(['category' => '125 SENIOR TDM SUPEROK'], $lastActivity->changes()->get('old'));
+
+    }
+
+    public function test_participants_not_in_tmd_categories_are_left_intact()
+    {
+
+        config([
+            'categories.default' => [
+                '125 SENIOR TDM ROK' => [
+                    'name' => '125 Senior Rok (TDM)',
+                    'tires' => 'MG_SM',
+                    'timekeeper_label' => '125 TAG SENIOR TERR',
+                    'enabled' => false,
+                ],
+        
+                '125 SENIOR TDM SUPEROK' => [
+                    'name' => '125 Senior Superok (TDM)',
+                    'tires' => 'MG_SM',
+                    'timekeeper_label' => '125 TAG SENIOR TERR',
+                    'enabled' => false,
+                ],
+
+                '125 SENIOR TERR' => [
+                    'name' => '125 Senior Territorial',
+                    'description' => 'For all engine trophies including TDM (e.g. X30, Rok, Rotax, ...)',
+                    'tires' => 'MG_SM',
+                    'timekeeper_label' => '125 TAG SENIOR TERR',
+                ],
+            ],
+        ]);
+
+        
+        $race = Race::factory()
+            ->create([
+                'event_start_at' => Carbon::parse("2023-02-28"),
+                'title' => 'Race title'
+            ]);
+        
+        $actual_participant = Participant::factory()->create([
+            'category' => '125 SENIOR TERR',
+            'race_id' => $race->getKey(),
+            'championship_id' => $race->championship->getKey(),
+        ]);
+
+        $this->artisan("operations:process", [
+                '--test' => true,
+                '2023_04_21_120712_move_participant_from_tdm_to_territorial',
+            ])
+            ->assertSuccessful();
+
+        $participant = $actual_participant->fresh();
+
+        $lastActivity = $participant->activities()->get()->last();
+
+        $this->assertEquals('125 SENIOR TERR', $participant->category);
+        $this->assertEquals('created', $lastActivity->event);
+        $this->assertEquals('participant', $lastActivity->subject_type);
+    }
+}


### PR DESCRIPTION
- Migrate TDM categories to Territorial in order to simplify the registration procedure as TDM ones are based on engine manufacturer