### PR TITLE
Update 100 and 125 Legend according to championship

### DIFF
--- a/config/categories.php
+++ b/config/categories.php
@@ -283,15 +283,20 @@ return [
             'tires' => 'VEGA_SL4',
             'timekeeper_label' => '100 LEGEND',
         ],
-        '125 LEGEND AIR' => [
-            'name' => '125 Legend Aria',
+        '100 LEGEND OVER 40' => [
+            'name' => '100 Legend Over 40',
+            'tires' => 'VEGA_SL4',
+            'timekeeper_label' => '100 LEGEND OVER 40',
+        ],
+        '125 LEGEND' => [
+            'name' => '125 Legend',
             'tires' => 'VEGA_SL4',
             'timekeeper_label' => '125 LEGEND',
         ],
-        '125 LEGEND WATER' => [
-            'name' => '125 Legend Acqua',
+        '125 LEGEND OVER 40' => [
+            'name' => '125 Legend Over 40',
             'tires' => 'VEGA_SL4',
-            'timekeeper_label' => '125 LEGEND',
+            'timekeeper_label' => '125 LEGEND OVER 40',
         ],
     ]
 


### PR DESCRIPTION
Rename 100 and 125 legend categories according to [ACI 2023 legend championship rules](https://www.acisport.it/public_federazione/2023/pdf/Annuario/campionato_italiano_karting_100_125_legend_2023_v6.pdf) and [classification](https://acisport.it/public/2023/pdf/CIK/2023_7292System.String[]//Classifica_piloti_Legend_100_classifiche_ci_kart_legend.pdf)